### PR TITLE
Bring back adapter auto-detection

### DIFF
--- a/packages/start/vite/plugin.js
+++ b/packages/start/vite/plugin.js
@@ -19,6 +19,7 @@ import routeDataHmr from "../server/routeDataHmr.js";
 import babelServerModule from "../server/server-functions/babel.js";
 import routeResource from "../server/serverResource.js";
 
+const require = createRequire(import.meta.url);
 const requireCwd = createRequire(join(process.cwd(), 'dummy.js'));
 
 // @ts-ignore
@@ -660,28 +661,37 @@ function find(locate, cwd) {
   return find(locate, path.join(cwd, ".."));
 }
 
-// const nodeModulesPath = find("node_modules", process.cwd());
+function detectAdapter() {
+  const startPkgJson = require("../package.json");
+  const supportedAdapters = Array.from(Object.keys(startPkgJson.devDependencies)).filter(
+    name => name.startsWith("solid-start-")
+  );
+  const cwdPackageJson = JSON.parse(
+    fs.readFileSync(path.join(process.cwd(), "package.json"), "utf-8")
+  );
+  const allDepdenencies = Array.from(Object.keys({
+    ...cwdPackageJson.dependencies,
+    ...cwdPackageJson.devDependencies
+  }));
 
-// function detectAdapter() {
-//   let adapters = [];
-//   fs.readdirSync(nodeModulesPath).forEach(dir => {
-//     if (dir.startsWith("solid-start-")) {
-//       const pkg = JSON.parse(
-//         fs.readFileSync(path.join(nodeModulesPath, dir, "package.json"), {
-//           encoding: "utf8"
-//         })
-//       );
-//       if (pkg.solid && pkg.solid.type === "adapter") {
-//         adapters.push(dir);
-//       }
-//     }
-//   });
+  /**
+   * @type {string[]}
+   */
+  let adapters = [];
+  allDepdenencies.forEach(dep => {
+    if (supportedAdapters.includes(dep)) {
+      const pkg = requireCwd(`${dep}/package.json`);
+      if (pkg.solid?.type === "adapter") {
+        adapters.push(dep);
+      }
+    }
+  });
 
-//   // Ignore the default adapter.
-//   adapters = adapters.filter(adapter => adapter !== "solid-start-node");
+  // Ignore the default adapter.
+  adapters = adapters.filter(adapter => adapter !== "solid-start-node");
 
-//   return adapters.length > 0 ? adapters[0] : "solid-start-node";
-// }
+  return adapters.length > 0 ? adapters[0] : "solid-start-node";
+}
 
 const findAny = (path, name, exts = [".js", ".ts", ".jsx", ".tsx", ".mjs", ".mts"]) => {
   for (var ext of exts) {
@@ -699,7 +709,7 @@ const findAny = (path, name, exts = [".js", ".ts", ".jsx", ".tsx", ".mjs", ".mts
 export default function solidStart(options) {
   options = Object.assign(
     {
-      adapter: process.env.START_ADAPTER ? process.env.START_ADAPTER : "solid-start-node",
+      adapter: process.env.START_ADAPTER ? process.env.START_ADAPTER : detectAdapter(),
       appRoot: "src",
       routesDir: "routes",
       ssr: process.env.START_SSR === "false" ? false : true,


### PR DESCRIPTION
# Summary 

Follow-up to #676.

I couldn't find the reason for reverting auto-detection in this commit:
https://github.com/solidjs/solid-start/commit/fc65a21e86122da186e3fd98b4cb57fe8d5c8046

But in case we actually want it back, but resilient to hoisting scenarios, this PR does just that.